### PR TITLE
Add support for minor versions of Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "minimum-stability": "stable",
   "require": {
     "php": "^7.2.5|^8.0|^8.1|^8.2|^8.3|^8.4",
-    "illuminate/support": "^7.0|^8.0|9.0|10.0|11.0|12.0"
+    "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "mudassar1/pesapal",
+  "name": "knox/pesapal",
   "description": "A laravel package that integrates into the pesapal api",
   "keywords": [
     "pesapal",


### PR DESCRIPTION
Since v2 of this library, there is an issue with illuminate/support version constraints. It allowed only initial releases of Laravel framework: 9.0.0, 10.0.0, 11.0.0 and 12.0.0. 

This PR fixes this issue by also allowing minor versions, i.e. 9.*

It also reverts package name back to `knox/pesapal` so that it can be loaded trough Composer.